### PR TITLE
Python backfill

### DIFF
--- a/frequency/backfill.py
+++ b/frequency/backfill.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import csv
+import argparse
+import collections
+from typing import List, Dict, Any
+
+
+# ===== from anki-connect ===== #
+# https://github.com/FooSoft/anki-connect#python
+import json
+import urllib.request
+def request(action, **params):
+    return {'action': action, 'params': params, 'version': 6}
+def invoke(action, **params):
+    requestJson = json.dumps(request(action, **params)).encode('utf-8')
+    response = json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson)))
+    if len(response) != 2:
+        raise Exception('response has an unexpected number of fields')
+    if 'error' not in response:
+        raise Exception('response is missing required error field')
+    if 'result' not in response:
+        raise Exception('response is missing required result field')
+    if response['error'] is not None:
+        raise Exception(response['error'])
+    return response['result']
+# ============================= #
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "expr_field",
+        type=str,
+        help="exact field name to search for when comparing frequencies"
+    )
+
+    parser.add_argument(
+        "--freq-field",
+        type=str,
+        help="exact field name to fill with the frequency information",
+        default="Frequency"
+    )
+
+    parser.add_argument(
+        "--query",
+        type=str,
+        help="exact note query to send to Anki",
+        default=None,
+    )
+
+    parser.add_argument(
+        "-f",
+        "--files",
+        nargs="+",
+        type=str,
+        help="what lists to use to backfill",
+        default=["JPDB.txt", "vnsfreq.txt", "vnsfreqSTARS.txt"],
+    )
+
+    return parser.parse_args()
+
+# freq is a string since it's not parsed at all by the csv.reader
+def create_actions(ids: List[int], freq: str, freq_field: str) -> List[Dict[str, Any]]:
+    actions = []
+    for i in ids:
+        a = {
+            "action": "updateNoteFields",
+            "version": 6,
+            "params": {
+                "note": {
+                    "id": i,
+                    "fields": {
+                        freq_field: freq
+                    }
+                }
+            }
+        }
+        actions.append(a)
+    return actions
+
+
+def main():
+    args = get_args()
+
+    query = args.query
+    if query is None:
+        query = f"{args.freq_field}:" # queries all notes with an empty frequency field
+    print(f"Querying Anki with: '{query}'")
+    notes = invoke("findNotes", query=query)
+
+    if len(notes) == 0:
+        print("Cannot find any notes to change. Exiting...")
+        return
+    print(f"Query found {len(notes)} notes.")
+
+    print("Getting note info...")
+    notes_info = invoke("notesInfo", notes=notes)
+
+    # dict[str, list[int]]
+    expr_to_nid = collections.defaultdict(list)
+    for note_info in notes_info:
+        expr = note_info["fields"][args.expr_field]["value"]
+        expr_to_nid[expr].append(note_info["noteId"])
+
+    # creates multi action to update multiple notes
+    actions = []
+
+    print("Parsing frequency lists...")
+    found_exprs = set()
+    for file_path in args.files:
+        with open(file_path, encoding="utf-8") as f:
+            for line in csv.reader(f, dialect=csv.excel_tab):
+                expr, freq = line
+                if expr not in found_exprs and expr in expr_to_nid:
+                    new_actions = create_actions(expr_to_nid[expr], freq, args.freq_field)
+                    actions.extend(new_actions)
+                    found_exprs.add(expr)
+
+    confirm = input(f"This will change {len(actions)} notes. Type 'yes' to confirm, or anything else to exit.\n> ")
+    if confirm != "yes":
+        print("Reply was not 'yes'. Exiting...")
+        return
+
+    print("Updating notes within Anki...")
+    invoke("multi", actions=actions)
+
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 <details>
 <summary><b>Backfilling: Command Line</b></summary>
 
-- Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed. Any version of Python above 3.8 should work.
+- Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed. Any Python version 3.8 or above should work.
 - Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
 - Open Anki. If you just installed AnkiConnect, make sure to restart Anki so AnkiConnect is properly running.
 - Run the following commands:

--- a/readme.md
+++ b/readme.md
@@ -112,12 +112,14 @@ Alternatively, after installing Advanced Browser, you could sort by the frequenc
 
 ### Backfilling Old Cards
 
-If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. There are two methods listed below to do exactly that. The command line method runs much faster than the Anki method, but requires some command line knowledge to pull off. Of course, you could just opt to finish reviewing these cards first instead of backfilling the old cards.
+If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. There are two methods listed below to do exactly that. The command line method runs much faster than the Anki method, but requires some command line knowledge to pull off.
 
-> **Warning**: Before trying either method below, **make sure to backup your collection beforehand.**
+Of course, you could just opt to finish reviewing these cards first instead of backfilling the old cards.
+
+> **Warning**: **Make sure to backup your collection** before trying either method below.
 
 <details>
-<summary><b>Command Line (Python script)</b></summary>
+<summary><b>Backfilling: Command Line</b></summary>
 
 - Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed.
 - Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
@@ -137,7 +139,7 @@ If you already have a large backlog of old cards without frequency values, you m
 </details>
 
 <details>
-<summary><b>Within Anki</b></summary>
+<summary><b>Backfilling: Within Anki</b></summary>
 
 - This is a hacky method to backfill your old cards. Again, **make sure to backup your collection before attempting this, it could cause significant lag to your Anki.** In addition, for users of Anki 2.1.50+ [increase your backup interval](https://docs.ankiweb.net/backups.html?highlight=backup#anki-2150) before attempting the import as it will take a _long_ time. A backup occurring while you're waiting on Anki to delete cards will just cause more lag.
 

--- a/readme.md
+++ b/readme.md
@@ -121,7 +121,7 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 <details>
 <summary><b>Backfilling: Command Line</b></summary>
 
-- Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed.
+- Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed. Any version of Python above 3.8 should work.
 - Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
 - Open Anki. If you just installed AnkiConnect, make sure to restart Anki so AnkiConnect is properly running.
 - Run the following commands:

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,33 @@ Alternatively, after installing Advanced Browser, you could sort by the frequenc
 
 ### Backfilling Old Cards
 
-If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. You could just opt to finish reviewing these cards first, but there is a hacky method to backfill these cards. **Make sure to backup your collection before attempting this, it could cause significant lag to your Anki.** In addition, for users of Anki 2.1.50+ [increase your backup interval](https://docs.ankiweb.net/backups.html?highlight=backup#anki-2150) before attempting the import as it will take a _long_ time. A backup occurring while you're waiting on Anki to delete cards will just cause more lag.
+If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. There are two methods listed below to do exactly that. Of course, you could just opt to finish reviewing these cards first instead of backfilling the old cards.
+
+<details>
+<summary><b>Command Line (Python script)</b></summary>
+
+- Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed.
+- Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
+- Open Anki, so that AnkiConnect is running.
+- Run the following commands:
+    ```bash
+    git clone https://github.com/MarvNC/JP-Resources.git
+    cd JP-Resources
+    cd backfill
+
+    # - Linux users may have to use `python3` instead of `python`.
+    # - Run `python backfill.py --help` to view all arguments.
+    # - Replace "Expression" with the exact field name that contains the word/expression.
+    python backfill.py "Expression"
+    ```
+
+</details>
+
+<details>
+<summary><b>Within Anki</b></summary>
+
+> **Warning**: This is a hacky method to backfill these cards. **Make sure to backup your collection before attempting this, it could cause significant lag to your Anki.** In addition, for users of Anki 2.1.50+ [increase your backup interval](https://docs.ankiweb.net/backups.html?highlight=backup#anki-2150) before attempting the import as it will take a _long_ time. A backup occurring while you're waiting on Anki to delete cards will just cause more lag.
+
 
 - Create a frequency list in `.txt` format that contains a list of expressions followed by frequency values. You can use the ones I have created [here](frequency), I recommend downloading the [JPDB](frequency/JPDB.txt) list as it's the most exhaustive. However the [VN Stars](frequency/vnsfreqSTARS.txt) list also fills in some of the gaps that JPDB doesn't cover, so you could import it first, then import JPDB afterward for maximum frequency coverage.
 
@@ -123,13 +149,16 @@ If you already have a large backlog of old cards without frequency values, you m
 
 - With this temporary deck selected, go to File -> Import, then select the txt frequency list. Map the first field to your term/expression field, then the second field to your frequency field. **Make sure to enable "Update existing notes when first field matches."** Then import it to your temporary deck.
 
-![](images/anki_Import_2022-07-10_10-47-55.png)
+    ![](images/anki_Import_2022-07-10_10-47-55.png)
 
 - This will update your existing notes' frequency values, but it'll also import a LOT of new unneeded cards.
 
   - Search for your backlogged cards using `tag:backlog` and then again hit `ctrl + a` then `ctrl + d` to move them back to your vocabulary deck. Now we can simply delete the temporary deck along with the all the new cards that were added, just **make sure** you aren't deleting any actual cards first.
 
 - Finally, you can right click the `backlog` tag in the sidebar and delete it.
+
+</details>
+
 
 ## Anki Card Blur
 

--- a/readme.md
+++ b/readme.md
@@ -112,7 +112,9 @@ Alternatively, after installing Advanced Browser, you could sort by the frequenc
 
 ### Backfilling Old Cards
 
-If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. There are two methods listed below to do exactly that. Of course, you could just opt to finish reviewing these cards first instead of backfilling the old cards.
+If you already have a large backlog of old cards without frequency values, you might need to fill in these values first or they won't be sorted. There are two methods listed below to do exactly that. The command line method runs much faster than the Anki method, but requires some command line knowledge to pull off. Of course, you could just opt to finish reviewing these cards first instead of backfilling the old cards.
+
+> **Warning**: Before trying either method below, **make sure to backup your collection beforehand.**
 
 <details>
 <summary><b>Command Line (Python script)</b></summary>
@@ -127,7 +129,7 @@ If you already have a large backlog of old cards without frequency values, you m
     cd backfill
 
     # - Linux users may have to use `python3` instead of `python`.
-    # - Run `python backfill.py --help` to view all arguments.
+    # - Run `python backfill.py --help` to view all possible arguments.
     # - Replace "Expression" with the exact field name that contains the word/expression.
     python backfill.py "Expression"
     ```
@@ -137,8 +139,7 @@ If you already have a large backlog of old cards without frequency values, you m
 <details>
 <summary><b>Within Anki</b></summary>
 
-> **Warning**: This is a hacky method to backfill these cards. **Make sure to backup your collection before attempting this, it could cause significant lag to your Anki.** In addition, for users of Anki 2.1.50+ [increase your backup interval](https://docs.ankiweb.net/backups.html?highlight=backup#anki-2150) before attempting the import as it will take a _long_ time. A backup occurring while you're waiting on Anki to delete cards will just cause more lag.
-
+- This is a hacky method to backfill your old cards. Again, **make sure to backup your collection before attempting this, it could cause significant lag to your Anki.** In addition, for users of Anki 2.1.50+ [increase your backup interval](https://docs.ankiweb.net/backups.html?highlight=backup#anki-2150) before attempting the import as it will take a _long_ time. A backup occurring while you're waiting on Anki to delete cards will just cause more lag.
 
 - Create a frequency list in `.txt` format that contains a list of expressions followed by frequency values. You can use the ones I have created [here](frequency), I recommend downloading the [JPDB](frequency/JPDB.txt) list as it's the most exhaustive. However the [VN Stars](frequency/vnsfreqSTARS.txt) list also fills in some of the gaps that JPDB doesn't cover, so you could import it first, then import JPDB afterward for maximum frequency coverage.
 

--- a/readme.md
+++ b/readme.md
@@ -149,7 +149,7 @@ Of course, you could just opt to finish reviewing these cards first instead of b
     python backfill.py "Expression" --freq-field "FrequencySort"
 
     # Uses a custom query instead of the default ("Frequency:").
-    python backfill.py "Expression" --query "Frequency: \\\"note:My mining note\\\""
+    python backfill.py "Expression" --query "Frequency: \"note:My mining note\""
 
     # Changes the order of which frequency list is used first.
     python backfill.py "Expression" --freq-lists "vnsfreq.txt" "JPDB.txt"

--- a/readme.md
+++ b/readme.md
@@ -130,8 +130,8 @@ Of course, you could just opt to finish reviewing these cards first instead of b
     cd JP-Resources
     cd frequency
 
-    # - Linux users may have to use `python3` instead of `python`.
-    # - Replace "Expression" with the exact field name that contains the word/expression.
+    # Linux users might have to use `python3` instead of `python`.
+    # Replace "Expression" with the exact field name that contains the word/expression.
     python backfill.py "Expression"
     ```
 

--- a/readme.md
+++ b/readme.md
@@ -131,9 +131,28 @@ Of course, you could just opt to finish reviewing these cards first instead of b
     cd frequency
 
     # - Linux users may have to use `python3` instead of `python`.
-    # - Run `python backfill.py --help` to view all possible arguments.
     # - Replace "Expression" with the exact field name that contains the word/expression.
     python backfill.py "Expression"
+    ```
+
+    Here are some more examples on how to use `backfill.py`:
+    ```bash
+    # View all possible arguments.
+    python backfill.py --help
+
+    # Searches for the expression in the field "Word" instead of "Expression"
+    # Note that this is case sensitive!
+    python backfill.py "Word"
+
+    # Uses the field "FrequencySort" instead of the default ("Frequency").
+    # This also changes the default query to `FrequencySort:`.
+    python backfill.py "Expression" --freq-field "FrequencySort"
+
+    # Uses a custom query instead of the default ("Frequency:").
+    python backfill.py "Expression" --query "Frequency: \\\"note:My mining note\\\""
+
+    # Changes the order of which frequency list is used first.
+    python backfill.py "Expression" --freq-lists "vnsfreq.txt" "JPDB.txt"
     ```
 
 </details>

--- a/readme.md
+++ b/readme.md
@@ -123,12 +123,12 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 
 - Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed.
 - Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
-- Open Anki, so that AnkiConnect is running.
+- Open Anki. If you just installed AnkiConnect, make sure to restart Anki so AnkiConnect is properly running.
 - Run the following commands:
     ```bash
-    git clone https://github.com/MarvNC/JP-Resources.git
+    git clone "https://github.com/MarvNC/JP-Resources.git"
     cd JP-Resources
-    cd backfill
+    cd frequency
 
     # - Linux users may have to use `python3` instead of `python`.
     # - Run `python backfill.py --help` to view all possible arguments.


### PR DESCRIPTION
Added a Python script using AnkiConnect in order to backfill the old cards much faster than the current method documented (for me, it ran within 10 seconds when updating 1.7k cards). By default, it takes frequencies in order of `"JPDB.txt", "vnsfreq.txt", "vnsfreqSTARS.txt"`.

Example --help invocation:
```
$ python3 backfill.py --help
usage: backfill.py [-h] [--freq-field FREQ_FIELD] [--query QUERY] [--freq-lists FREQ_LISTS [FREQ_LISTS ...]]
                   expr_field

positional arguments:
  expr_field            exact field name that contains the expression

optional arguments:
  -h, --help            show this help message and exit
  --freq-field FREQ_FIELD
                        exact field name to fill with the frequency information (default: Frequency)
  --query QUERY         exact note query to send to Anki
  --freq-lists FREQ_LISTS [FREQ_LISTS ...]
                        what lists to use to backfill (default: ['JPDB.txt', 'vnsfreq.txt', 'vnsfreqSTARS.txt'])
```

Example usage:
```
$ python3 backfill.py "Word" --freq-field "FrequencySort"
Querying Anki with: 'FrequencySort:'
Query found 1793 notes.
Getting note info...
Parsing frequency lists...
This will change 1746 notes. Type 'yes' to confirm, or anything else to exit.
> yes
Updating notes within Anki...
Done!
```