### PR TITLE
Added a way to specify a default value for backfill.py

### DIFF
--- a/frequency/backfill.py
+++ b/frequency/backfill.py
@@ -36,10 +36,10 @@ def invoke(action, **params):
 
 # =========================================================================== #
 
-pattern = re.compile("<.*?>")
+rx_HTML = re.compile("<.*?>")
 
 def remove_html(expression: str):
-    return re.sub(pattern, '', expression)
+    return re.sub(rx_HTML, '', expression)
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(

--- a/frequency/backfill.py
+++ b/frequency/backfill.py
@@ -150,7 +150,7 @@ def main():
     if args.default is None:
         input_msg = f"This will change {len(actions)} notes ({len(notes) - len(actions)} notes had no frequencies found). Type 'yes' to confirm, or anything else to exit.\n> "
     else:
-        input_msg = f"This will change {len(actions)} notes ({len(actions) - added_freqs_n} notes had no frequencies and will be set to {args.default}). Type 'yes' to confirm, or anything else to exit.\n> "
+        input_msg = f"This will change {len(actions)} notes ({len(actions) - added_freqs_n} notes had no frequencies found and will be set to {args.default}). Type 'yes' to confirm, or anything else to exit.\n> "
 
     confirm = input(input_msg)
     if confirm != "yes":

--- a/frequency/backfill.py
+++ b/frequency/backfill.py
@@ -7,15 +7,11 @@ import re
 from typing import List, Dict, Any
 
 
-# ===== from anki-connect ===== #
+# ========================== from anki-connect =========================== #
+
 # https://github.com/FooSoft/anki-connect#python
 import json
 import urllib.request
-
-pattern = re.compile("<.*?>")
-
-def remove_html(expression: str):
-    return re.sub(pattern, '', expression)
 
 def request(action, **params):
     return {"action": action, "params": params, "version": 6}
@@ -38,9 +34,12 @@ def invoke(action, **params):
         raise Exception(response["error"])
     return response["result"]
 
+# =========================================================================== #
 
-# ============================= #
+pattern = re.compile("<.*?>")
 
+def remove_html(expression: str):
+    return re.sub(pattern, '', expression)
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -51,6 +50,13 @@ def get_args() -> argparse.Namespace:
         "expr_field",
         type=str,
         help="exact field name that contains the expression",
+    )
+
+    parser.add_argument(
+        "--default",
+        type=int,
+        help="default value to fill for cards with no frequencies listed",
+        default=None,
     )
 
     parser.add_argument(
@@ -132,9 +138,21 @@ def main():
                     actions.extend(new_actions)
                     found_exprs.add(expr)
 
-    confirm = input(
-        f"This will change {len(actions)} notes. Type 'yes' to confirm, or anything else to exit.\n> "
-    )
+    added_freqs_n = len(actions)
+    if args.default is not None:
+        for expr in expr_to_nid.keys():
+            if expr not in found_exprs:
+                new_actions = create_actions(
+                    expr_to_nid[expr], str(args.default), args.freq_field
+                )
+                actions.extend(new_actions)
+
+    if args.default is None:
+        input_msg = f"This will change {len(actions)} notes ({len(notes) - len(actions)} notes had no frequencies found). Type 'yes' to confirm, or anything else to exit.\n> "
+    else:
+        input_msg = f"This will change {len(actions)} notes ({len(actions) - added_freqs_n} notes had no frequencies and will be set to {args.default}). Type 'yes' to confirm, or anything else to exit.\n> "
+
+    confirm = input(input_msg)
     if confirm != "yes":
         print("Reply was not 'yes'. Exiting...")
         return

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,9 @@ Of course, you could just opt to finish reviewing these cards first instead of b
   # Note that this is case sensitive!
   python backfill.py "Word"
 
+  # Sets all expressions without any found frequencies to the default value of '0'.
+  python backfill.py "Expression" --default 0
+
   # Uses the field "FrequencySort" instead of the default ("Frequency").
   # This also changes the default query to `FrequencySort:`.
   python backfill.py "Expression" --freq-field "FrequencySort"

--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,10 @@ Of course, you could just opt to finish reviewing these cards first instead of b
   #     --query "Frequency: \`"note:My mining note\`""
   python backfill.py "Expression" --query "Frequency: \"note:My mining note\""
 
+  # This custom query can be used to override all of your existing frequencies,
+  # instead of just backfilling. RUN THIS WITH CAUTION!
+  python backfill.py "Expression" --query "\"note:My mining note\""
+
   # Changes the order of which frequency list is used first.
   python backfill.py "Expression" --freq-lists "vnsfreq.txt" "JPDB.txt"
   ```


### PR DESCRIPTION
This adds the `--default` flag for `backfill.py`, so you can specify something like `--default 0` to set the cards without frequencies to 0. People should be able to re-run the script with this flag if they already ran the script once, to set all notes that had no frequencies found to 0.

This also fixes a few small things I didn't catch from stazor's PR:
- The `remove_html` function was placed incorrectly in the ankiconnect section, so now it's moved it underneath it instead and the separation is a bit more apparent.
- The `pattern` variable was renamed to `rx_HTML` to better represent what it does.