### PR TITLE
Add warning for WSL users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,6 +370,7 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 - Install the latest version of [Python](https://www.python.org/downloads/) if you do not have it already installed. Any Python version 3.8 or above should work.
 - Install [AnkiConnect](https://ankiweb.net/shared/info/2055492159) if you do not have it already installed.
 - Open Anki. If you just installed AnkiConnect, make sure to restart Anki so AnkiConnect is properly running.
+    - Note that this will not work via [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) due to networking constraints. If you are on Windows you will have to use Command Prompt or Powershell.
 - Run the following commands:
 
   ```bash


### PR DESCRIPTION
For WSL users, it is worth noting that AnkiConnect's port will be inaccessible due to the swamp that is WSL Distro <-> Native Windows networking.