### PR TITLE
Override the {freq} value for grammar dictionaries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@ Add my thoughts on a few frequency dictionaries.
 
 # `freq` Changelog
 
+## v23.02.25.2
+- Fixed default `opt-grammar-override-dict-regex` not being properly escaped
+
 ## v23.02.25.1
 - Added option to override the frequency for grammar dictionaries
 

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@ Add my thoughts on a few frequency dictionaries.
 
 # `freq` Changelog
 
+## v23.02.26.1
+- Added missing `絵でわかる日本語` grammar dictionary
+
 ## v23.02.25.3
 - Fixed grammar dictionaries not being detected if "Result grouping mode" is set to "No Grouping"
 

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@ Add my thoughts on a few frequency dictionaries.
 
 # `freq` Changelog
 
+## v23.02.25.3
+- Fixed grammar dictionaries not being detected if "Result grouping mode" is set to "No Grouping"
+
 ## v23.02.25.2
 - Fixed default `opt-grammar-override-dict-regex` not being properly escaped
 

--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,9 @@ Add my thoughts on a few frequency dictionaries.
 
 # `freq` Changelog
 
+## v23.02.25.1
+- Added option to override the frequency for grammar dictionaries
+
 ## v23.02.05.1
 - Changed the default sorting method from `min` to `harmonic`
 

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
     ```handlebars
     {{#*inline "freq"}}
-        {{~! Frequency sort handlebars: v23.02.25.3 ~}}
+        {{~! Frequency sort handlebars: v23.02.26.1 ~}}
         {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources ~}}
         {{~#scope~}}
             {{~! Options ~}}
@@ -91,7 +91,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
             {{~set "opt-grammar-override" true ~}}
             {{~set "opt-grammar-override-value" 0 ~}}
-            {{~#set "opt-grammar-override-dict-regex"~}} ^(日本語文法辞典\(全集\)|毎日のんびり日本語教師|JLPT文法解説まとめ|どんなときどう使う 日本語表現文型辞典)$ {{~/set~}}
+            {{~#set "opt-grammar-override-dict-regex"~}} ^(日本語文法辞典\(全集\)|毎日のんびり日本語教師|JLPT文法解説まとめ|どんなときどう使う 日本語表現文型辞典|絵でわかる日本語)$ {{~/set~}}
             {{~! End of options ~}}
 
             {{~! Do not change the code below unless you know what you are doing. ~}}

--- a/readme.md
+++ b/readme.md
@@ -315,7 +315,10 @@ and view the lines right below `{{#*inline "freq"}}`.
     > This may incorrectly override some terms that might not be considered as a grammar point.
     > For example, 以前 can be used as a standalone word, but is an entry under the
     > **毎日のんびり日本語教師** dictionary.
-    > Adding word will have a frequency value of 0.
+    > In other words, with this feature enabled, 以前 will have a `{freq}` value of 0.
+    >
+    > This incorrect override usually only happens for very common words anyways
+    > (JPDB ranks 以前 as 721), so this should not be a very big problem.
 
     The following table summarizes the options related to this.
 

--- a/readme.md
+++ b/readme.md
@@ -300,7 +300,24 @@ and view the lines right below `{{#*inline "freq"}}`.
 <details>
 <summary><b>Default Value For Grammar Dictionaries</b></summary>
 
-*   TODO
+*   By default, if you create a card for any grammar point,
+    the frequency will be automatically set to `0`.
+    This is because it is very likely that
+    you would want to prioritize reviewing grammar points as much as possible.
+
+    The `{freq}` handlebars code determines whether a card is a grammar point or not by
+    your installed [grammar dictionaries](https://github.com/aiko-tanaka/Grammar-Dictionaries).
+    If the definition within the exported term contains any grammar dictionary,
+    then it is considered as a grammar point. Otherwise, the term is treated
+    like any other term.
+
+    The following table summarizes the options related to this.
+
+    | Option | Description |
+    |-|-|
+    | `opt-grammar-override` | If set to `true` (default), overrides the resulting frequency with `opt-grammar-override-value` if at least one dictionary is determined to be a grammar dictionary. Set this variable to `false` in order to disable the behavior. |
+    | `opt-grammar-override-value` | The exact frequency value used for grammar dictionaries. |
+    | `opt-grammar-override-dict-regex` | The regex used in order to determine if a dictionary is a grammar dictionary. Edit this like any other `dict-regex` variable, i.e. by concatenating strings with `|`. |
 
 
 </details>

--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,17 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
             {{~set "t" 1 ~}}
             {{~set "found-grammar-dict" false ~}}
 
+            {{~! search for grammar dictionary ~}}
+            {{~#each definition.definitions~}}
+                {{~#set "rx-match-grammar-dicts" ~}}
+                    {{~#regexMatch (get "opt-grammar-override-dict-regex") "gu"~}}{{this.dictionary}}{{~/regexMatch~}}
+                {{/set~}}
+                {{~! rx-match-grammar-dicts is not empty if a grammar dictionary was found ~}}
+                {{~#if (op "!==" (get "rx-match-grammar-dicts") "") ~}}
+                    {{~set "found-grammar-dict" true ~}}
+                {{/if~}}
+            {{~/each~}}
+
             {{~#each definition.frequencies~}}
 
                 {{~! rx-match-ignored-freq is not empty if ignored <=> rx-match-ignored-freq is empty if not ignored ~}}
@@ -107,14 +118,6 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
                     {{~#regexMatch (get "opt-ignored-freq-dict-regex") "gu"~}}{{this.dictionary}}{{~/regexMatch~}}
                 {{/set~}}
                 {{~#if (op "===" (get "rx-match-ignored-freq") "") ~}}
-
-                    {{~#set "rx-match-grammar-dicts" ~}}
-                        {{~#regexMatch (get "opt-grammar-override-dict-regex") "gu"~}}{{this.dictionary}}{{~/regexMatch~}}
-                    {{/set~}}
-                    {{~! rx-match-grammar-dicts is not empty if a grammar dictionary was found ~}}
-                    {{~#if (op "!==" (get "rx-match-grammar-dicts") "") ~}}
-                        {{~set "found-grammar-dict" true ~}}
-                    {{/if~}}
 
                     {{~!
                         only uses the 1st frequency of any dictionary.

--- a/readme.md
+++ b/readme.md
@@ -317,7 +317,7 @@ and view the lines right below `{{#*inline "freq"}}`.
     |-|-|
     | `opt-grammar-override` | If set to `true` (default), overrides the resulting frequency with `opt-grammar-override-value` if at least one dictionary is determined to be a grammar dictionary. Set this variable to `false` in order to disable the behavior. |
     | `opt-grammar-override-value` | The exact frequency value used for grammar dictionaries. |
-    | `opt-grammar-override-dict-regex` | The regex used in order to determine if a dictionary is a grammar dictionary. Edit this like any other `dict-regex` variable, i.e. by concatenating strings with `|`. |
+    | `opt-grammar-override-dict-regex` | The regex used in order to determine if a dictionary is a grammar dictionary. Edit this like any other `dict-regex` variable, i.e. by concatenating strings with `\|`. |
 
 
 </details>

--- a/readme.md
+++ b/readme.md
@@ -312,10 +312,9 @@ and view the lines right below `{{#*inline "freq"}}`.
     like any other term.
 
     > **Note**:
-    > This may incorrectly override some terms that might not be considered as a grammar point.
-    > For example, 以前 can be used as a standalone word, but is an entry under the
-    > **毎日のんびり日本語教師** dictionary.
-    > In other words, with this feature enabled, 以前 will have a `{freq}` value of 0.
+    > This may incorrectly override the frequency for some terms that might not be considered as a grammar point.
+    > For example, 以前 can be used as a standalone word, but is an entry under the **毎日のんびり日本語教師** dictionary.
+    > In other words, with this feature enabled, 以前 will have its `{freq}` value incorrectly overwritten (to 0 by default).
     >
     > This incorrect override usually only happens for very common words anyways
     > (JPDB ranks 以前 as 721), so this should not be a very big problem.

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
     ```handlebars
     {{#*inline "freq"}}
-        {{~! Frequency sort handlebars: v23.02.05.1 ~}}
+        {{~! Frequency sort handlebars: v23.02.25.1 ~}}
         {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources ~}}
         {{~#scope~}}
             {{~! Options ~}}
@@ -88,12 +88,17 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
             {{~#set "opt-keep-freqs-past-first-regex"~}} ^()$ {{~/set~}}
             {{~set "opt-no-freq-default-value" 0 ~}}
             {{~set "opt-freq-sorting-method" "harmonic" ~}} {{~! "min", "first", "avg", "harmonic" ~}}
+
+            {{~set "opt-grammar-override" true ~}}
+            {{~set "opt-grammar-override-value" 0 ~}}
+            {{~#set "opt-grammar-override-dict-regex"~}} ^(日本語文法辞典(全集)|毎日のんびり日本語教師|JLPT文法解説まとめ|どんなときどう使う 日本語表現文型辞典)$ {{~/set~}}
             {{~! End of options ~}}
 
             {{~! Do not change the code below unless you know what you are doing. ~}}
             {{~set "result-freq" -1 ~}} {{~! -1 is chosen because no frequency dictionaries should have an entry as -1 ~}}
             {{~set "prev-freq-dict" "" ~}}
             {{~set "t" 1 ~}}
+            {{~set "found-grammar-dict" false ~}}
 
             {{~#each definition.frequencies~}}
 
@@ -102,6 +107,14 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
                     {{~#regexMatch (get "opt-ignored-freq-dict-regex") "gu"~}}{{this.dictionary}}{{~/regexMatch~}}
                 {{/set~}}
                 {{~#if (op "===" (get "rx-match-ignored-freq") "") ~}}
+
+                    {{~#set "rx-match-grammar-dicts" ~}}
+                        {{~#regexMatch (get "opt-grammar-override-dict-regex") "gu"~}}{{this.dictionary}}{{~/regexMatch~}}
+                    {{/set~}}
+                    {{~! rx-match-grammar-dicts is not empty if a grammar dictionary was found ~}}
+                    {{~#if (op "!==" (get "rx-match-grammar-dicts") "") ~}}
+                        {{~set "found-grammar-dict" true ~}}
+                    {{/if~}}
 
                     {{~!
                         only uses the 1st frequency of any dictionary.
@@ -215,6 +228,16 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
                     )
                 ~}}
             {{~/if~}}
+
+            {{~! override final result if grammar dictionary ~}}
+            {{~#if (
+                op "&&"
+                    (op "===" (get "found-grammar-dict") true)
+                    (op "===" (get "opt-grammar-override") true)
+                )
+            ~}}
+                {{~set "result-freq" (get "opt-grammar-override-value") ~}}
+            {{/if}}
 
             {{~get "result-freq"~}}
         {{~/scope~}}

--- a/readme.md
+++ b/readme.md
@@ -311,6 +311,12 @@ and view the lines right below `{{#*inline "freq"}}`.
     then it is considered as a grammar point. Otherwise, the term is treated
     like any other term.
 
+    > **Note**:
+    > This may incorrectly override some terms that might not be considered as a grammar point.
+    > For example, 以前 can be used as a standalone word, but is an entry under the
+    > **毎日のんびり日本語教師** dictionary.
+    > Adding word will have a frequency value of 0.
+
     The following table summarizes the options related to this.
 
     | Option | Description |

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
     ```handlebars
     {{#*inline "freq"}}
-        {{~! Frequency sort handlebars: v23.02.25.2 ~}}
+        {{~! Frequency sort handlebars: v23.02.25.3 ~}}
         {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources ~}}
         {{~#scope~}}
             {{~! Options ~}}
@@ -110,6 +110,15 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
                     {{~set "found-grammar-dict" true ~}}
                 {{/if~}}
             {{~/each~}}
+
+            {{~! Additional case when "Result grouping mode" is set to "No Grouping"~}}
+            {{~#set "rx-match-grammar-dicts" ~}}
+                {{~#regexMatch (get "opt-grammar-override-dict-regex") "gu"~}}{{this.definition.dictionary}}{{~/regexMatch~}}
+            {{/set~}}
+            {{~! rx-match-grammar-dicts is not empty if a grammar dictionary was found ~}}
+            {{~#if (op "!==" (get "rx-match-grammar-dicts") "") ~}}
+                {{~set "found-grammar-dict" true ~}}
+            {{/if~}}
 
             {{~#each definition.frequencies~}}
 

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
     ```handlebars
     {{#*inline "freq"}}
-        {{~! Frequency sort handlebars: v23.02.25.1 ~}}
+        {{~! Frequency sort handlebars: v23.02.25.2 ~}}
         {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources ~}}
         {{~#scope~}}
             {{~! Options ~}}
@@ -91,7 +91,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
 
             {{~set "opt-grammar-override" true ~}}
             {{~set "opt-grammar-override-value" 0 ~}}
-            {{~#set "opt-grammar-override-dict-regex"~}} ^(日本語文法辞典(全集)|毎日のんびり日本語教師|JLPT文法解説まとめ|どんなときどう使う 日本語表現文型辞典)$ {{~/set~}}
+            {{~#set "opt-grammar-override-dict-regex"~}} ^(日本語文法辞典\(全集\)|毎日のんびり日本語教師|JLPT文法解説まとめ|どんなときどう使う 日本語表現文型辞典)$ {{~/set~}}
             {{~! End of options ~}}
 
             {{~! Do not change the code below unless you know what you are doing. ~}}
@@ -285,6 +285,14 @@ and view the lines right below `{{#*inline "freq"}}`.
     ```handlebars
     {{~set "opt-no-freq-default-value" 99999999~}}
     ```
+
+</details>
+
+<details>
+<summary><b>Default Value For Grammar Dictionaries</b></summary>
+
+*   TODO
+
 
 </details>
 


### PR DESCRIPTION
This PR adds the feature of overriding the {freq} output value if a downloaded grammar dictionary is shown in the exported term.

TODO:
- [x] Documentation
- [x] Test for a day or two