### PR TITLE
backfill.py: Default query now checks for a non-empty expression field

### DIFF
--- a/frequency/backfill.py
+++ b/frequency/backfill.py
@@ -104,7 +104,7 @@ def main():
         query = args.query
     else:
         # queries all notes with an empty frequency field
-        query = f"{args.freq_field}:"
+        query = f'"{args.expr_field}:*" "{args.freq_field}:"'
     print(f"Querying Anki with: '{query}'")
     notes = invoke("findNotes", query=query)
 

--- a/readme.md
+++ b/readme.md
@@ -474,10 +474,10 @@ Of course, you could just opt to finish reviewing these cards first instead of b
   python backfill.py "Expression" --default 0
 
   # Uses the field "FrequencySort" instead of the default ("Frequency").
-  # This also changes the default query to `FrequencySort:`.
+  # This also changes the default query to search an empty `FrequencySort` field.
   python backfill.py "Expression" --freq-field "FrequencySort"
 
-  # Uses a custom query instead of the default ("Frequency:").
+  # Uses a custom query instead of the default ("Expression:* Frequency:").
   # Note: For powershell users, you must escape the quotes with an additional backtick:
   #     --query "Frequency: \`"note:My mining note\`""
   python backfill.py "Expression" --query "Frequency: \"note:My mining note\""


### PR DESCRIPTION
Previously, the default query was only `Frequency:`, which has a chance of selecting unwanted note types (since it will query all notes that have an empty `Frequency` field regardless of note type). The new query is now `Expression:* Frequency:`, which searches for any note that has an `Expression` field, and an empty `Frequency` field. Although this still bears the risk of selecting unwanted note types, the unwanted note types must have both fields present + an empty `Frequency` field, which is considerably rarer than just having an empty `Frequency` field.