### PR TITLE
Add reference to my plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ My contributions to the Japanese learning community. For questions and support, 
   - [`freq` Settings](#freq-settings)
   - [Usage](#usage)
   - [Backfilling Old Cards](#backfilling-old-cards)
+  - [Fitting in your own cards](#fitting-in-your-own-cards)
 - [Anki Card Blur](#anki-card-blur)
   - [How-To](#how-to-1)
   - [Usage](#usage-1)
@@ -539,6 +540,10 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 - Finally, you can right click the `backlog` tag in the sidebar and delete it.
 
 </details>
+
+
+### Fitting in your own cards
+If you frequently make your own cards from scratch, you won't be able to pull frequencies from dictionaries. If you tag all of these cards specifically, you can use [this plugin](https://github.com/HunterKing/anki-frequency-shuffle).
 
 ## Anki Card Blur
 

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ My contributions to the Japanese learning community. For questions and support, 
   - [`freq` Settings](#freq-settings)
   - [Usage](#usage)
   - [Backfilling Old Cards](#backfilling-old-cards)
-  - [Fitting in your own cards](#fitting-in-your-own-cards)
+  - [Fitting in Cards Without Frequencies](#fitting-in-cards-without-frequencies)
 - [Anki Card Blur](#anki-card-blur)
   - [How-To](#how-to-1)
   - [Usage](#usage-1)
@@ -541,9 +541,9 @@ Of course, you could just opt to finish reviewing these cards first instead of b
 
 </details>
 
+### Fitting in Cards Without Frequencies
 
-### Fitting in your own cards
-If you frequently make your own cards from scratch, you won't be able to pull frequencies from dictionaries. If you tag all of these cards specifically, you can use [this plugin](https://github.com/HunterKing/anki-frequency-shuffle).
+If you frequently make cards that don't contain frequencies, such as sentence or grammar cards, you won't be able to pull frequencies from dictionaries. If you tag all of these cards specifically, you can use [this plugin](https://github.com/HunterKing/anki-frequency-shuffle) to generate random frequencies for these cards.
 
 ## Anki Card Blur
 


### PR DESCRIPTION
I have written a simple plugin which allows users to specify a tag, and a range of values to "shuffle" cards with a frequency value, so that their self-made cards can more easily be integrated with the flow of new cards. I am doing a shameless self-plug.

It's available here: https://github.com/HunterKing/anki-frequency-shuffle