### PR TITLE
Ignore Wanikani Freq Dict

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ This handlebar for Yomichan will add a `{freq}` field that will use your install
       {{~! The latest version can be found at https://github.com/MarvNC/JP-Resources#freq-handlebar ~}}
       {{~#scope~}}
           {{~! Options ~}}
-          {{~#set "opt-ignored-freq-dict-regex"~}} ^(JLPT.*)|(HSK.*)$ {{~/set~}}
+          {{~#set "opt-ignored-freq-dict-regex"~}} ^(JLPT.*)|(HSK.*)|(WK.*)$ {{~/set~}}
           {{~#set "opt-ignored-freq-value-regex"~}} ❌ {{~/set~}}
           {{~#set "opt-keep-freqs-past-first-regex"~}} ^()$ {{~/set~}}
           {{~set "opt-no-freq-default-value" 9999999 ~}}


### PR DESCRIPTION
Hi - I'm using this great [WaniKani level dict](https://community.wanikani.com/t/yomichan-addon-jlpt-and-wanikani-level-tags/55567) for Yomitan and was confused why my frequency values were all way too low. It would be nice to merge this change so your great solution can become more plug-and-play for less technical people (or those without spare debugging time) 😉

Thanks for your hard work!

